### PR TITLE
Render links in text.

### DIFF
--- a/process-hangouts-json.py
+++ b/process-hangouts-json.py
@@ -27,7 +27,7 @@ def start(fname):
 
                 for segment in event[
                         'chat_message']['message_content']['segment']:
-                    if segment['type'] == 'TEXT':
+                    if segment['type'] == 'TEXT' or segment['type'] == 'LINK':
                         text.append(segment['text'])
                         
                 sender = participants.get(


### PR DESCRIPTION
The json has both a link name and target, but the target appears just to
link through the Google redirector, so rendering just the link name
should be fine.